### PR TITLE
Upgrades CodeSniffer to 3.x for PHP 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ Inside your project ```composer.json``` file add the package to the require-dev 
 
 ```
 "require-dev": {
-    "phpunit/phpunit": "4.5.*",
+    "phpunit/phpunit": "5.5.*",
     "ve-interactive/php-sniffer-rules": "dev-master"
 },
 ```
 
-Because the project is currently inside a private repository the repository itself needs to be added to the composer file.
-
+The repo yneeds to be added to the composer file:
 ```
 "repositories": [
     {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inside your project ```composer.json``` file add the package to the require-dev 
 },
 ```
 
-The repo yneeds to be added to the composer file:
+The repo needs to be added to the composer file:
 ```
 "repositories": [
     {

--- a/TestFiles/Fail/Test.php
+++ b/TestFiles/Fail/Test.php
@@ -58,6 +58,22 @@ class Foo extends Bar implements FooInterface
 	}
 
 	/**
+	 * @param boolean $b
+	 */
+	public function testBoolean($b)
+	{
+
+	}
+
+	/**
+	 * @param boolean $b
+	 */
+	public function testBoolean2(boolean $b)
+	{
+
+	}
+
+	/**
 	 * @param mixed ...$test
 	 * @param mixed $test2
 	 */

--- a/TestFiles/Pass/AbstractTest2.php
+++ b/TestFiles/Pass/AbstractTest2.php
@@ -88,8 +88,8 @@ abstract class AbstractTest2
 	 * @param array  $var3
 	 */
 	protected function newLines(
-		$var,
-		$var2,
+		string $var,
+		string $var2,
 		array $var3
 	)
 	{

--- a/TestFiles/Pass/AbstractTest2.php
+++ b/TestFiles/Pass/AbstractTest2.php
@@ -93,8 +93,6 @@ abstract class AbstractTest2
 		array $var3
 	)
 	{
-
-
 	}
 
 	/**
@@ -103,6 +101,5 @@ abstract class AbstractTest2
 	 */
 	protected function variadic(&$variable, ...$test)
 	{
-
 	}
 }

--- a/TestFiles/Pass/Test.php
+++ b/TestFiles/Pass/Test.php
@@ -21,10 +21,10 @@ class Test extends Bar implements FooInterface
 	/**
 	 * Some text
 	 *
-	 * @param string  $a
-	 * @param boolean $b
+	 * @param string $a
+	 * @param bool   $b
 	 */
-	public function sampleFunction($a, $b = false)
+	public function sampleFunction(string $a, bool $b = false)
 	{
 		if ($a === $b)
 		{

--- a/TestFiles/Pass/Test.php
+++ b/TestFiles/Pass/Test.php
@@ -62,7 +62,6 @@ class Test extends Bar implements FooInterface
 		$variableName = 'foo';
 
 		$fn = function() {
-
 		};
 	}
 

--- a/Ve/Sniffs/Classes/AbstractClassNameSniff.php
+++ b/Ve/Sniffs/Classes/AbstractClassNameSniff.php
@@ -1,11 +1,17 @@
 <?php
 
+namespace Ve\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Checks if the abstract class name has the Abstract prefix.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_Classes_AbstractClassNameSniff implements PHP_CodeSniffer_Sniff
+class AbstractClassNameSniff implements Sniff
 {
 	const PREFIX = 'Abstract';
 
@@ -24,18 +30,18 @@ class Ve_Sniffs_Classes_AbstractClassNameSniff implements PHP_CodeSniffer_Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in
+     *                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens  = $phpcsFile->getTokens();
         $className = $tokens[$phpcsFile->findNext(T_STRING, $stackPtr)]['content'];
 
-		if ($tokens[$stackPtr -2]['code'] === T_ABSTRACT && strpos($className, self::PREFIX) !== 0)
+		if ($tokens[$stackPtr - 2]['code'] === T_ABSTRACT && strpos($className, self::PREFIX) !== 0)
 		{
 			$phpcsFile->addError('The abstract class "' . $className . '" does not have the "' . self::PREFIX . '" prefix in its name.', $stackPtr, 'WrongName');
 		}

--- a/Ve/Sniffs/Classes/InterfaceClassNameSniff.php
+++ b/Ve/Sniffs/Classes/InterfaceClassNameSniff.php
@@ -1,11 +1,17 @@
 <?php
 
+namespace Ve\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * Checks if the interfaces contain either the suffix or prefix.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_Classes_InterfaceClassNameSniff implements PHP_CodeSniffer_Sniff
+class InterfaceClassNameSniff implements Sniff
 {
 	const SUFFIX = 'Interface';
 	const PREFIX = 'I';
@@ -27,13 +33,13 @@ class Ve_Sniffs_Classes_InterfaceClassNameSniff implements PHP_CodeSniffer_Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in
+     *                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens  = $phpcsFile->getTokens();
         $className = $tokens[$phpcsFile->findNext(T_STRING, $stackPtr)]['content'];

--- a/Ve/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Ve/Sniffs/Commenting/FunctionCommentSniff.php
@@ -16,6 +16,14 @@ use PHP_CodeSniffer\Util\Common as PHP_CodeSniffer_Common;
 class FunctionCommentSniff extends OtherFunctionCommentSniff
 {
 
+	public static $allowedTypes = [
+		'array',
+		'mixed',
+		'object',
+		'resource',
+		'callable',
+	];
+
 	public $treatNullAsInternalType = true;
 
 	/**
@@ -190,7 +198,7 @@ class FunctionCommentSniff extends OtherFunctionCommentSniff
 				}
 				else if (count($typeNames) === 1)
 				{
-					$allowedTypes = PHP_CodeSniffer_Common::$allowedTypes;
+					$allowedTypes = self::$allowedTypes;
 
 					if ($this->treatNullAsInternalType)
 					{
@@ -427,6 +435,21 @@ class FunctionCommentSniff extends OtherFunctionCommentSniff
 		if (substr($typeName, -2) === '[]') {
 			return 'array';
 		}
+
+		switch ($typeName)
+		{
+			case 'int':
+			case 'integer':
+				return 'int';
+			case 'string':
+				return 'string';
+			case 'bool':
+			case 'boolean':
+				return 'bool';
+			case 'float':
+				return 'float';
+		}
+
 		return PHP_CodeSniffer_Common::suggestType($typeName);
 	}
 

--- a/Ve/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Ve/Sniffs/Commenting/FunctionCommentSniff.php
@@ -1,15 +1,19 @@
 <?php
-if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false)
-{
-	throw new PHP_CodeSniffer_Exception('Class PEAR_Sniffs_Commenting_FunctionCommentSniff not found');
-}
+
+namespace Ve\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException as PHP_CodeSniffer_RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff as OtherFunctionCommentSniff;
+use PHP_CodeSniffer\Util\Common as PHP_CodeSniffer_Common;
 
 /**
  * Parses and verifies the doc comments for functions.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_Commenting_FunctionCommentSniff extends Squiz_Sniffs_Commenting_FunctionCommentSniff
+class FunctionCommentSniff extends OtherFunctionCommentSniff
 {
 
 	public $treatNullAsInternalType = true;
@@ -17,15 +21,15 @@ class Ve_Sniffs_Commenting_FunctionCommentSniff extends Squiz_Sniffs_Commenting_
 	/**
 	 * Process the function parameter comments.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-	 * @param int                  $stackPtr     The position of the current token
-	 *                                           in the stack passed in $tokens.
-	 * @param int                  $commentStart The position in the stack where the comment started.
+	 * @param File $phpcsFile    The file being scanned.
+	 * @param int  $stackPtr     The position of the current token
+	 *                           in the stack passed in $tokens.
+	 * @param int  $commentStart The position in the stack where the comment started.
 	 *
 	 * @return void
 	 */
 	protected function processParams(
-		PHP_CodeSniffer_File $phpcsFile,
+		File $phpcsFile,
 		$stackPtr,
 		$commentStart
 	)
@@ -186,7 +190,7 @@ class Ve_Sniffs_Commenting_FunctionCommentSniff extends Squiz_Sniffs_Commenting_
 				}
 				else if (count($typeNames) === 1)
 				{
-					$allowedTypes = PHP_CodeSniffer::$allowedTypes;
+					$allowedTypes = PHP_CodeSniffer_Common::$allowedTypes;
 
 					if ($this->treatNullAsInternalType)
 					{
@@ -423,7 +427,7 @@ class Ve_Sniffs_Commenting_FunctionCommentSniff extends Squiz_Sniffs_Commenting_
 		if (substr($typeName, -2) === '[]') {
 			return 'array';
 		}
-		return PHP_CodeSniffer::suggestType($typeName);
+		return PHP_CodeSniffer_Common::suggestType($typeName);
 	}
 
 	/**
@@ -443,18 +447,20 @@ class Ve_Sniffs_Commenting_FunctionCommentSniff extends Squiz_Sniffs_Commenting_
 	 * Parameters with default values have an additional array index of
 	 * 'default' with the value of the default as a string.
 	 *
-	 * @param int $stackPtr The position in the stack of the T_FUNCTION token
-	 *                      to acquire the parameters for.
+	 * @param int   $stackPtr  The position in the stack of the T_FUNCTION token
+	 *                         to acquire the parameters for.
+	 * @param File  $phpcsFile
+	 * @param array $tokens
 	 *
 	 * @return array
-	 * @throws PHP_CodeSniffer_Exception If the specified $stackPtr is not of
+	 * @throws PHP_CodeSniffer_RuntimeException If the specified $stackPtr is not of
 	 *                                   type T_FUNCTION.
 	 */
 	private function getMethodParametersWithVariadic($stackPtr, $phpcsFile, $tokens)
 	{
 		if ($tokens[$stackPtr]['code'] !== T_FUNCTION)
 		{
-			throw new PHP_CodeSniffer_Exception('$stackPtr must be of type T_FUNCTION');
+			throw new PHP_CodeSniffer_RuntimeException('$stackPtr must be of type T_FUNCTION');
 		}
 
 		$opener = $tokens[$stackPtr]['parenthesis_opener'];

--- a/Ve/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/Ve/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -1,11 +1,18 @@
 <?php
 
+namespace Ve\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
 /**
  * Verifies that control statements conform to their coding standards.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniffer_Sniff
+class ControlSignatureSniff implements Sniff
 {
 	/**
 	 * A list of tokenizers this sniff supports.
@@ -40,13 +47,13 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param int                  $stackPtr  The position of the current token in the
-	 *                                        stack passed in $tokens.
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the
+	 *                        stack passed in $tokens.
 	 *
 	 * @return void
 	 */
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	public function process(File $phpcsFile, $stackPtr)
 	{
 		$tokens = $phpcsFile->getTokens();
 
@@ -63,7 +70,7 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 		else if ($tokens[$stackPtr]['code'] === T_ELSE || $tokens[$stackPtr]['code'] === T_ELSEIF
 		)
 		{
-			$closer = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens,
+			$closer = $phpcsFile->findPrevious(Tokens::$emptyTokens,
 				($stackPtr - 1), null, true);
 			if ($closer === false || $tokens[$closer]['code'] !== T_CLOSE_CURLY_BRACKET)
 			{
@@ -81,12 +88,12 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 	}
 
 	/**
-	 * @param array $tokens
+	 * @param array   $tokens
 	 * @param integer $stackPtr
-	 * @param PHP_CodeSniffer_File $phpcsFile
+	 * @param File    $phpcsFile
 	 */
 	private function checkSingleSpaceAfterKeyword(array $tokens, $stackPtr,
-											   PHP_CodeSniffer_File $phpcsFile)
+											   File $phpcsFile)
 	{
 		if (in_array($tokens[$stackPtr]['code'], [T_TRY, T_DO, T_ELSE]))
 		{
@@ -139,12 +146,12 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 	}
 
 	/**
-	 * @param array $tokens
+	 * @param array   $tokens
 	 * @param integer $stackPtr
-	 * @param PHP_CodeSniffer_File $phpcsFile
+	 * @param File    $phpcsFile
 	 */
 	private function checkNewLineAfterClosingParenthesis(array $tokens, $stackPtr,
-													  PHP_CodeSniffer_File $phpcsFile)
+													  File $phpcsFile)
 	{
 		if (isset($tokens[$stackPtr]['parenthesis_closer']) === true && isset($tokens[$stackPtr]['scope_opener'])
 			=== true
@@ -159,10 +166,10 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 	/**
 	 * @param array $tokens
 	 * @param integer $stackPtr
-	 * @param PHP_CodeSniffer_File $phpcsFile
+	 * @param File $phpcsFile
 	 */
 	private function checkNewLineAfterOpeningBrace(array $tokens, $stackPtr,
-												PHP_CodeSniffer_File $phpcsFile)
+												$phpcsFile)
 	{
 		if (isset($tokens[$stackPtr]['scope_opener']) === true)
 		{
@@ -205,10 +212,10 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 	 * @param array $tokens
 	 * @param integer $pointer
 	 * @param string $pointerName
-	 * @param PHP_CodeSniffer_File $phpcsFile
+	 * @param File $phpcsFile
 	 */
 	private function checkNewLineAfterPointer(array $tokens, $pointer,
-										   $pointerName, PHP_CodeSniffer_File $phpcsFile)
+										   $pointerName, File $phpcsFile)
 	{
 		for ($next = ($pointer + 1); $next < $phpcsFile->numTokens; $next++)
 		{
@@ -221,7 +228,7 @@ class Ve_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSniff
 			}
 
 			// Skip all empty tokens on the same line as the opener.
-			if ($tokens[$next]['line'] === $tokens[$pointer]['line'] && isset(PHP_CodeSniffer_Tokens::$emptyTokens[$code])
+			if ($tokens[$next]['line'] === $tokens[$pointer]['line'] && isset(Tokens::$emptyTokens[$code])
 				=== true
 			)
 			{

--- a/Ve/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/Ve/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -1,73 +1,83 @@
 <?php
 
+namespace Ve\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\MultiLineFunctionDeclarationSniff as OtherMultiLineFunctionDeclarationSniff;
+
 /**
  * Ensure single and multi-line function declarations are defined correctly.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_Functions_MultiLineFunctionDeclarationSniff extends Squiz_Sniffs_Functions_MultiLineFunctionDeclarationSniff
+class MultiLineFunctionDeclarationSniff extends OtherMultiLineFunctionDeclarationSniff
 {
+   /**
+    * @var array
+    */
+    private $stopTokens = ['T_SEMICOLON', 'T_ABSTRACT', 'T_CLOSE_CURLY_BRACKET'];
 
    /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
         $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
 
-		if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
-			// Must be one space after the FUNCTION keyword.
-			if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
-				$spaces = 'newline';
-			} else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-				$spaces = strlen($tokens[($stackPtr + 1)]['content']);
-			} else {
-				$spaces = 0;
-			}
+        if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
+            // Must be one space after the FUNCTION keyword.
+            if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
+                $spaces = 'newline';
+            } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                $spaces = strlen($tokens[($stackPtr + 1)]['content']);
+            } else {
+                $spaces = 0;
+            }
 
-			if ($spaces !== 1) {
-				$error = 'Expected 1 space after FUNCTION keyword; %s found';
-				$data  = array($spaces);
-				$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterFunction', $data);
-				if ($fix === true) {
-					if ($spaces === 0) {
-						$phpcsFile->fixer->addContent($stackPtr, ' ');
-					} else {
-						$phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
-					}
-				}
-			}
-		} else {
-			if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
-				$spaces = 'newline';
-			} else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-				$spaces = strlen($tokens[($stackPtr + 1)]['content']);
-			} else {
-				$spaces = 0;
-			}
+            if ($spaces !== 1) {
+                $error = 'Expected 1 space after FUNCTION keyword; %s found';
+                $data  = array($spaces);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterFunction', $data);
+                if ($fix === true) {
+                    if ($spaces === 0) {
+                        $phpcsFile->fixer->addContent($stackPtr, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    }
+                }
+            }
+        } else {
+            if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
+                $spaces = 'newline';
+            } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                $spaces = strlen($tokens[($stackPtr + 1)]['content']);
+            } else {
+                $spaces = 0;
+            }
 
-			if ($spaces === 1) {
-				$error = 'Expected 0 space after FUNCTION keyword on closure; %s found';
-				$data  = array($spaces);
-				$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterClosure', $data);
-				if ($fix === true) {
-					if ($spaces === 0) {
-						$phpcsFile->fixer->addContent($stackPtr, ' ');
-					} else {
-						$phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
-					}
-				}
-			}
-		}
+            if ($spaces === 1) {
+                $error = 'Expected 0 space after FUNCTION keyword on closure; %s found';
+                $data  = array($spaces);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterClosure', $data);
+                if ($fix === true) {
+                    if ($spaces === 0) {
+                        $phpcsFile->fixer->addContent($stackPtr, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    }
+                }
+            }
+        }
 
         // Must be one space before the opening parenthesis. For closures, this is
         // enforced by the first check because there is no content between the keywords
@@ -166,16 +176,16 @@ class Ve_Sniffs_Functions_MultiLineFunctionDeclarationSniff extends Squiz_Sniffs
 
     }
 
-	/**
-	 * Override of the multiline sniffer to enforce new line after the closing parenthesis.
-	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile
-	 * @param integer $stackPtr
-	 * @param array $tokens
-	 */
-	public function processMultiLineDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    /**
+     * Override of the multiline sniffer to enforce new line after the closing parenthesis.
+     *
+     * @param File    $phpcsFile
+     * @param integer $stackPtr
+     * @param array   $tokens
+     */
+    public function processMultiLineDeclaration($phpcsFile, $stackPtr, $tokens)
     {
-		// We need to work out how far indented the function
+        // We need to work out how far indented the function
         // declaration itself is, so we can work out how far to
         // indent parameters.
         $functionIndent = 0;
@@ -328,12 +338,12 @@ class Ve_Sniffs_Functions_MultiLineFunctionDeclarationSniff extends Squiz_Sniffs
             }
         }
 
-		// from parent
+        // from parent
 
-		$openBracket = $tokens[$stackPtr]['parenthesis_opener'];
+        $openBracket = $tokens[$stackPtr]['parenthesis_opener'];
         $this->processBracket($phpcsFile, $openBracket, $tokens, 'function');
 
-		$this->checkOpenCurlyBrackets($phpcsFile, $stackPtr, $tokens, $functionIndent);
+        $this->checkOpenCurlyBrackets($phpcsFile, $stackPtr, $tokens, $functionIndent);
 
         if ($tokens[$stackPtr]['code'] !== T_CLOSURE) {
             return;
@@ -353,26 +363,33 @@ class Ve_Sniffs_Functions_MultiLineFunctionDeclarationSniff extends Squiz_Sniffs
         } else {
             $gap = 0;
         }
-	}
+    }
 
-	/**
-	 * Checks the indentation of opening curly brackets
-	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile
-	 * @param integer $stackPtr
-	 * @param array $tokens
-	 * @param integer $functionIndent
-	 */
-	private function checkOpenCurlyBrackets(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens, $functionIndent)
-	{
-		$openCurlyBracket = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($tokens[$stackPtr]['parenthesis_closer'] + 1));
-		$actualIndentation = $tokens[$openCurlyBracket]['column'] - 1;
+    /**
+     * Checks the indentation of opening curly brackets
+     *
+     * @param File    $phpcsFile
+     * @param integer $stackPtr
+     * @param array   $tokens
+     * @param integer $functionIndent
+     */
+    private function checkOpenCurlyBrackets(File $phpcsFile, $stackPtr, $tokens, $functionIndent)
+    {
+        $openCurlyBracket = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($tokens[$stackPtr]['parenthesis_closer'] + 1));
+        $actualIndentation = $tokens[$openCurlyBracket]['column'] - 1;
 
-		if ($functionIndent !== $actualIndentation) {
-			$phpcsFile->addError('There should be ' . $functionIndent . ' spaces before the opening bracket. ' . $actualIndentation . ' found.', $openCurlyBracket, 'OpeningBraketIndentation');
-		}
+        if ($functionIndent !== $actualIndentation) {
+            $abstractPtr = $stackPtr;
+            while (
+                --$abstractPtr > 0
+                && ! in_array($tokens[$abstractPtr]['type'], $this->stopTokens)
+            );
 
-	}
+            if ($tokens[$abstractPtr]['type'] !== 'T_ABSTRACT')
+            {
+                $phpcsFile->addError('There should be ' . $functionIndent . ' spaces before the opening bracket. ' . $actualIndentation . ' found.', $openCurlyBracket, 'OpeningBraketIndentation');
+            }
+        }
 
-
+    }
 }

--- a/Ve/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Ve/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,11 +1,17 @@
 <?php
 
+namespace Ve\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
  * Verifies that variable names are all camelCase.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_NamingConventions_ValidVariableNameSniff implements PHP_CodeSniffer_Sniff
+class ValidVariableNameSniff implements Sniff
 {
 
 	/**
@@ -22,13 +28,12 @@ class Ve_Sniffs_NamingConventions_ValidVariableNameSniff implements PHP_CodeSnif
 	/**
 	 * Processes the tokens that this sniff is interested in.
 	 *
-	 * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-	 * @param int                  $stackPtr  The position in the stack where
-	 *                                        the token was found.
+	 * @param File $phpcsFile The file where the token was found.
+	 * @param int  $stackPtr  The position in the stack where the token was found.
 	 *
 	 * @return void
 	 */
-	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	public function process(File $phpcsFile, $stackPtr)
 	{
 		$tokens = $phpcsFile->getTokens();
 		$variableName = $tokens[$stackPtr]['content'];
@@ -37,12 +42,12 @@ class Ve_Sniffs_NamingConventions_ValidVariableNameSniff implements PHP_CodeSnif
 		}
 
 		if ($variableName{1} !== strtolower($variableName{1})) {
-			$phpcsFile->addError('The first character of a variable name must be lowercase.', $stackPtr);
+			$phpcsFile->addError('The first character of a variable name must be lowercase.', $stackPtr, '');
 		}
 
 		if (strpos($variableName, '_') !== false)
 		{
-			$phpcsFile->addError('Variable names must be camelCase.', $stackPtr);
+			$phpcsFile->addError('Variable names must be camelCase.', $stackPtr, '');
 		}
 	}
 

--- a/Ve/Sniffs/PHP/DisallowLongArraySyntaxSniff.php
+++ b/Ve/Sniffs/PHP/DisallowLongArraySyntaxSniff.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Ve\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
 /**
  * This sniff prohibits the use of the old array() syntax.
  *
@@ -22,8 +27,9 @@
  * </code>
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_PHP_DisallowLongArraySyntaxSniff implements PHP_CodeSniffer_Sniff
+class DisallowLongArraySyntaxSniff implements Sniff
 {
     /**
      * Returns the token types that this sniff is interested in.
@@ -38,13 +44,13 @@ class Ve_Sniffs_PHP_DisallowLongArraySyntaxSniff implements PHP_CodeSniffer_Snif
     /**
      * Processes the tokens that this sniff is interested in.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-     * @param int                  $stackPtr  The position in the stack where
-     *                                        the token was found.
+     * @param File $phpcsFile The file where the token was found.
+     * @param int  $stackPtr  The position in the stack where
+     *                        the token was found.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$stackPtr]['content'] === 'array') {

--- a/Ve/Sniffs/WhiteSpaces/SpaceAfterNegateOperatorSniff.php
+++ b/Ve/Sniffs/WhiteSpaces/SpaceAfterNegateOperatorSniff.php
@@ -1,11 +1,17 @@
 <?php
 
+namespace Ve\Sniffs\WhiteSpaces;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
  * Verifies that the negate operator is always followed by a space.
  *
  * @author Nicola Puddu <nicola.puddu@veinteractive.com>
+ * @author Jack Blower  <Jack@elvenspellmaker.co.uk>
  */
-class Ve_Sniffs_WhiteSpaces_SpaceAfterNegateOperatorSniff implements PHP_CodeSniffer_Sniff
+class SpaceAfterNegateOperatorSniff implements Sniff
 {
 
     /**
@@ -19,23 +25,23 @@ class Ve_Sniffs_WhiteSpaces_SpaceAfterNegateOperatorSniff implements PHP_CodeSni
 
     }
 
-	/**
+    /**
      * Processes the tokens that this sniff is interested in.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-     * @param int                  $stackPtr  The position in the stack where
-     *                                        the token was found.
+     * @param File $phpcsFile The file where the token was found.
+     * @param int  $stackPtr  The position in the stack where the token was
+     *                        found.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-		if ($tokens[$stackPtr -1]['content'] == '!') {
-			$phpcsFile->addError('Missing space after the "!"', $stackPtr);
-		} elseif ($tokens[$stackPtr -1]['content'] == '(' && $tokens[$stackPtr -2]['content'] == '!') {
-			$phpcsFile->addError('Missing space after the "!"', $stackPtr);
-		}
+        if ($tokens[$stackPtr - 1]['content'] === '!') {
+            $phpcsFile->addError('Missing space after the "!"', $stackPtr, '');
+        } elseif ($tokens[$stackPtr - 1]['content'] === '(' && $tokens[$stackPtr - 2]['content'] == '!') {
+            $phpcsFile->addError('Missing space after the "!"', $stackPtr, '');
+        }
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,18 @@
     "name": "ve-interactive/php-sniffer-rules",
     "description": "additional code sniffer rules for php projects",
     "require": {
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "license": "MIT",
     "authors": [
         {
             "name": "Nic Puddu",
             "email": "nicola.puddu@veinteractive.com"
+        },
+        {
+            "name": "Jack Blower",
+            "email": "Jack@elvenspellmaker.co.uk"
         }
+
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,69 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d04b6712595026727edc3f89699e40ca",
+    "packages": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}


### PR DESCRIPTION
  * Upgrades CodeSniffer to 3.x for PHP 7 support
  * Also incorporates #5 into this PR

This needs careful planning as currently lots of projects use `*` (which they shouldn't)...